### PR TITLE
Fix: transactions from websockets not emitting an event

### DIFF
--- a/src/websockets/handler.rs
+++ b/src/websockets/handler.rs
@@ -68,8 +68,16 @@ pub async fn process_text_msg(
             amount,
             metadata,
         } => {
-            routes::transactions::make_transaction(pool, private_key, to, amount, metadata, msg_id,server)
-                .await
+            routes::transactions::make_transaction(
+                pool,
+                private_key,
+                to,
+                amount,
+                metadata,
+                msg_id,
+                server,
+            )
+            .await
         }
         WebSocketMessageInner::Work => WebSocketMessage {
             ok: Some(true),

--- a/src/websockets/handler.rs
+++ b/src/websockets/handler.rs
@@ -68,7 +68,7 @@ pub async fn process_text_msg(
             amount,
             metadata,
         } => {
-            routes::transactions::make_transaction(pool, private_key, to, amount, metadata, msg_id)
+            routes::transactions::make_transaction(pool, private_key, to, amount, metadata, msg_id,server)
                 .await
         }
         WebSocketMessageInner::Work => WebSocketMessage {

--- a/src/websockets/routes/transactions.rs
+++ b/src/websockets/routes/transactions.rs
@@ -3,8 +3,10 @@ use sqlx::{Pool, Postgres};
 
 use crate::{
     database::transaction::{TransactionCreateData, TransactionType},
-    models::websockets::{WebSocketMessage, WebSocketMessageInner, WebSocketMessageResponse,WebSocketEvent},
-    websockets::WebSocketServer
+    models::websockets::{
+        WebSocketEvent, WebSocketMessage, WebSocketMessageInner, WebSocketMessageResponse,
+    },
+    websockets::WebSocketServer,
 };
 
 use crate::database::transaction::Model as Transaction;
@@ -17,7 +19,7 @@ pub async fn make_transaction(
     amount: Decimal,
     metadata: Option<String>,
     msg_id: Option<usize>,
-    server: &WebSocketServer
+    server: &WebSocketServer,
 ) -> WebSocketMessage {
     let amount = amount.round_dp(2); // Make sure we do not support 2 decimals after the dot.
 


### PR DESCRIPTION
This fixes a bug where transactions sent using websockets do not fire a websocket event.