### PR TITLE
Implement query parameters for Krist endpoints

### DIFF
--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -135,7 +135,6 @@ impl<'q> Model {
         pool: &Pool<Postgres>,
         pagination: &PaginationParams,
     ) -> Result<Vec<Model>> {
-        tracing::info!("Limit was {:?}", pagination.limit);
         let limit = pagination.limit.unwrap_or(50);
         let offset = pagination.offset.unwrap_or(0);
         let limit = limit.clamp(1, 1000);

--- a/src/database/transaction.rs
+++ b/src/database/transaction.rs
@@ -139,10 +139,11 @@ impl<'q> Model {
         let offset = pagination.offset.unwrap_or(0);
         let limit = limit.clamp(1, 1000);
 
-        let q = if pagination.exclude_mined == Some(true) {
-            r#"SELECT * FROM transactions WHERE transaction_type != 'mined' ORDER BY date DESC LIMIT $1 OFFSET $2;"#
-        } else {
-            r#"SELECT * FROM transactions ORDER BY date DESC LIMIT $1 OFFSET $2;"#
+        let q = match pagination.exclude_mined {
+            Some(true) => {
+                r#"SELECT * FROM transactions WHERE transaction_type != 'mined' ORDER BY date DESC LIMIT $1 OFFSET $2;"#
+            }
+            _ => r#"SELECT * FROM transactions ORDER BY date DESC LIMIT $1 OFFSET $2;"#,
         };
 
         sqlx::query_as(q)

--- a/src/models/krist/addresses.rs
+++ b/src/models/krist/addresses.rs
@@ -58,6 +58,12 @@ impl From<wallet::Model> for AddressJson {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, PartialOrd, Serialize, Deserialize, Default)]
+pub struct AddressGetQuery {
+    #[serde(alias = "fetchNames")]
+    pub fetch_names: Option<bool>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/routes/krist/wallet.rs
+++ b/src/routes/krist/wallet.rs
@@ -52,10 +52,9 @@ async fn wallet_get(
 ) -> Result<HttpResponse, KristError> {
     let address = address.into_inner();
 
-    let wallet = if query.0.fetch_names == Some(true) {
-        Wallet::fetch_by_address_names(&state.pool, &address).await?
-    } else {
-        Wallet::fetch_by_address(&state.pool, &address).await?
+    let wallet = match query.0.fetch_names {
+        Some(true) => Wallet::fetch_by_address_names(&state.pool, &address).await?,
+        _ => Wallet::fetch_by_address(&state.pool, &address).await?,
     };
 
     wallet

--- a/src/routes/krist/wallet.rs
+++ b/src/routes/krist/wallet.rs
@@ -5,7 +5,9 @@ use crate::AppState;
 use crate::database::{ModelExt, name::Model as Name, wallet::Model as Wallet};
 use crate::errors::krist::KristError;
 use crate::errors::krist::address::AddressError;
-use crate::models::krist::addresses::{AddressJson, AddressListResponse, AddressResponse};
+use crate::models::krist::addresses::{
+    AddressGetQuery, AddressJson, AddressListResponse, AddressResponse,
+};
 use crate::models::krist::names::{NameJson, NameListResponse};
 use crate::models::krist::transactions::{
     AddressTransactionQuery, TransactionJson, TransactionListResponse,
@@ -46,10 +48,15 @@ async fn wallet_list(
 async fn wallet_get(
     state: web::Data<AppState>,
     address: web::Path<String>,
+    query: web::Query<AddressGetQuery>,
 ) -> Result<HttpResponse, KristError> {
     let address = address.into_inner();
 
-    let wallet = Wallet::fetch_by_address(&state.pool, &address).await?;
+    let wallet = if query.0.fetch_names == Some(true) {
+        Wallet::fetch_by_address_names(&state.pool, &address).await?
+    } else {
+        Wallet::fetch_by_address(&state.pool, &address).await?
+    };
 
     wallet
         .map(|addr| AddressResponse {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -41,6 +41,9 @@ pub fn config(cfg: &mut web::ServiceConfig) {
 
 #[derive(Debug, serde::Deserialize, serde::Serialize)]
 pub struct PaginationParams {
+    #[serde(alias = "excludeMined")]
+    // Only used on /transactions routes
+    pub exclude_mined: Option<bool>,
     pub limit: Option<i64>,
     pub offset: Option<i64>,
 }
@@ -48,6 +51,7 @@ pub struct PaginationParams {
 impl Default for PaginationParams {
     fn default() -> Self {
         Self {
+            exclude_mined: None,
             limit: Some(50),
             offset: Some(0),
         }


### PR DESCRIPTION
Small changes to add query parameters to `/transactions/latest` and `/addresses/<address>` as mentioned in #9. I tested as well as I could on my machine and believe that this should close the issue, but let me know if this needs fixes. I checked and had no conflicts merging #11 with these added changes so there shouldn't be any issues there. 