### PR TITLE
fix: ensure that all endpoints properly respect excludeMined param

### DIFF
--- a/src/database/wallet.rs
+++ b/src/database/wallet.rs
@@ -5,7 +5,6 @@ use sqlx::{Acquire, Encode, Executor, Pool, Postgres, Type};
 
 use crate::database::{DatabaseError, ModelExt, Result, name, transaction};
 use crate::errors::KromerError;
-use crate::models::krist::transactions::AddressTransactionQuery;
 use crate::routes::PaginationParams;
 use crate::utils::crypto;
 
@@ -161,15 +160,16 @@ impl<'q> Model {
             .await
     }
 
-    pub async fn total_transactions<E>(&self, executor: E) -> sqlx::Result<i64>
+    pub async fn total_transactions<E>(&self, executor: E, exclude_mined: bool) -> sqlx::Result<i64>
     where
         E: 'q + Executor<'q, Database = Postgres>,
     {
-        let q = r#"
-            SELECT COUNT(*)
-            FROM transactions
-            WHERE "from" = $1 OR "to" = $1;
-    "#;
+        let q = match exclude_mined {
+            true => {
+                r#"SELECT COUNT(*) FROM transactions WHERE ("from" = $1 OR "to" = $1) AND transaction_type != 'mined';"#
+            }
+            false => r#"SELECT COUNT(*) FROM transactions  WHERE "from" = $1 OR "to" = $1;"#,
+        };
 
         sqlx::query_scalar(q)
             .bind(&self.address)
@@ -180,21 +180,23 @@ impl<'q> Model {
     pub async fn transactions<E>(
         &self,
         pool: E,
-        query: &AddressTransactionQuery,
+        query: &PaginationParams,
     ) -> sqlx::Result<Vec<transaction::Model>>
     where
         E: 'q + Executor<'q, Database = Postgres>,
     {
-        let limit = query.limit.unwrap_or(50);
+        let limit = query.limit.unwrap_or(50).clamp(1, 1000);
         let offset = query.offset.unwrap_or(0);
-        let limit = limit.clamp(1, 1000);
 
-        let q = r#"
-        SELECT * FROM transactions
-        WHERE "from" = $1 OR "to" = $1
-        ORDER BY date DESC
-        LIMIT $2 OFFSET $3;
-    "#;
+        let q = match query.exclude_mined {
+            Some(true) => {
+                r#"SELECT * FROM transactions WHERE ("from" = $1 OR "to" = $1) AND transaction_type != 'mined' ORDER BY date DESC LIMIT $2 OFFSET $3;"#
+            }
+            _ => {
+                r#"SELECT * FROM transactions WHERE "from" = $1 OR "to" = $1 ORDER BY date DESC LIMIT $2 OFFSET $3;"#
+            }
+        };
+
         sqlx::query_as(q)
             .bind(&self.address)
             .bind(limit)

--- a/src/routes/krist/transactions.rs
+++ b/src/routes/krist/transactions.rs
@@ -29,13 +29,10 @@ pub async fn transaction_list(
     let params = query.into_inner();
     let pool = &state.pool;
 
-    let limit = params.limit.unwrap_or(50);
-    let offset = params.offset.unwrap_or(0);
-
     let mut tx = pool.begin().await?;
 
-    let total_transaction = Transaction::total_count(&mut *tx).await?;
-    let transactions = Transaction::fetch_all(&mut *tx, limit, offset).await?;
+    let total_transaction = Transaction::total_count_no_mined(&mut *tx, &params).await?;
+    let transactions = Transaction::fetch_all_no_mined(&mut *tx, &params).await?;
 
     tx.commit().await?;
 
@@ -155,7 +152,7 @@ async fn transaction_latest(
     let params = query.into_inner();
     let pool = &state.pool;
 
-    let total = Transaction::total_count(pool).await?;
+    let total = Transaction::total_count_no_mined(pool, &params).await?;
     let transactions = Transaction::sorted_by_date(pool, &params).await?;
 
     let transactions: Vec<TransactionJson> =


### PR DESCRIPTION
Implemented functionality for the [`/transactions`](https://krist.dev/docs/#api-TransactionGroup-GetTransactions) and [`/addresses/<address>/transactions`](https://krist.dev/docs/#api-AddressGroup-GetAddressTransactions) endpoint while also making sure that the total value returned respected the value in all endpoints ([`/transactions/latest`](https://krist.dev/docs/#api-TransactionGroup-GetLatestTransactions). Tested on my machine and it worked fine across all three endpoints.

Had to implement a couple of functions to avoid redefining traits. Also switched a couple of query parameters from `AddressTransactionQuery` to `PaginationParams` since the former is for the `includeMined` query param on lookup endpoints, not the correct `excludeMined` param used elsewhere. I had minor merge issues with #11 but was easy to resolve.

Should hopefully fix #14 and #15.