### PR TITLE
fix: kromer specific wallets return correct total_out

### DIFF
--- a/src/models/kromer/wallets.rs
+++ b/src/models/kromer/wallets.rs
@@ -29,7 +29,7 @@ impl From<wallet::Model> for Wallet {
             created_at: value.created_at,
             locked: value.locked,
             total_in: value.total_in,
-            total_out: value.total_in,
+            total_out: value.total_out,
             names: value.names,
         }
     }


### PR DESCRIPTION
Wallets in the Kromer API (not the Krist compatible API) returned total_in for total_out. Noticed while working on my crate and didn't think it warranted a full issue so just making a PR. Didn't test the change but it built and I can't imagine how this would possible break something (famous last words).