### PR TITLE
fix: deduplicate "responding_to" field on websocket responses

### DIFF
--- a/src/models/krist/websockets.rs
+++ b/src/models/krist/websockets.rs
@@ -24,7 +24,6 @@ pub enum WebSocketMessageInner {
         server_time: String,
     },
     Response {
-        responding_to: String,
         #[serde(flatten)]
         data: WebSocketMessageResponse,
     },

--- a/src/websockets/routes/addresses.rs
+++ b/src/websockets/routes/addresses.rs
@@ -47,7 +47,6 @@ pub async fn get_address(
         ok: Some(true),
         id: msg_id,
         r#type: WebSocketMessageInner::Response {
-            responding_to: "address".to_owned(),
             data: WebSocketMessageResponse::Address {
                 address: wallet.into(),
             },

--- a/src/websockets/routes/auth.rs
+++ b/src/websockets/routes/auth.rs
@@ -41,7 +41,6 @@ pub async fn perform_login(
                     ok: Some(true),
                     id: msg_id,
                     r#type: WebSocketMessageInner::Response {
-                        responding_to: "login".to_owned(),
                         data: WebSocketMessageResponse::Login {
                             is_guest: false,
                             address: Some(wallet.into()),
@@ -53,7 +52,6 @@ pub async fn perform_login(
                     ok: Some(true),
                     id: msg_id,
                     r#type: WebSocketMessageInner::Response {
-                        responding_to: "login".to_owned(),
                         data: WebSocketMessageResponse::Login {
                             is_guest: true,
                             address: None,
@@ -66,7 +64,6 @@ pub async fn perform_login(
             ok: Some(true),
             id: msg_id,
             r#type: WebSocketMessageInner::Response {
-                responding_to: "login".to_owned(),
                 data: WebSocketMessageResponse::Login {
                     is_guest: true,
                     address: None,
@@ -94,7 +91,6 @@ pub async fn perform_logout(
         ok: Some(true),
         id: msg_id,
         r#type: WebSocketMessageInner::Response {
-            responding_to: "logout".to_owned(),
             data: WebSocketMessageResponse::Logout { is_guest: true },
         },
     }

--- a/src/websockets/routes/me.rs
+++ b/src/websockets/routes/me.rs
@@ -29,7 +29,6 @@ pub async fn get_myself(
             ok: Some(true),
             id: msg_id,
             r#type: WebSocketMessageInner::Response {
-                responding_to: "me".to_owned(),
                 data: WebSocketMessageResponse::Me {
                     is_guest: true,
                     address: None,
@@ -74,7 +73,6 @@ pub async fn get_myself(
         ok: Some(true),
         id: msg_id,
         r#type: WebSocketMessageInner::Response {
-            responding_to: "me".to_owned(),
             data: WebSocketMessageResponse::Me {
                 is_guest: false,
                 address: Some(wallet_resp),

--- a/src/websockets/routes/subscriptions.rs
+++ b/src/websockets/routes/subscriptions.rs
@@ -29,7 +29,6 @@ pub async fn subscribe(
             ok: Some(true),
             id: msg_id,
             r#type: WebSocketMessageInner::Response {
-                responding_to: "subscribe".to_owned(),
                 data: WebSocketMessageResponse::Subscribe {
                     subscription_level: subscription_list,
                 },
@@ -69,7 +68,6 @@ pub async fn unsubscribe(
             ok: Some(true),
             id: msg_id,
             r#type: WebSocketMessageInner::Response {
-                responding_to: "subscribe".to_owned(),
                 data: WebSocketMessageResponse::Subscribe {
                     subscription_level: subscription_list,
                 },
@@ -104,7 +102,6 @@ pub async fn get_subscription_level(
         ok: Some(true),
         id: msg_id,
         r#type: WebSocketMessageInner::Response {
-            responding_to: "get_subscription_level".to_owned(),
             data: WebSocketMessageResponse::GetSubscriptionLevel {
                 subscription_level: subscription_list,
             },
@@ -131,7 +128,6 @@ pub async fn get_valid_subscription_levels(msg_id: Option<usize>) -> WebSocketMe
         ok: Some(true),
         id: msg_id,
         r#type: WebSocketMessageInner::Response {
-            responding_to: "get_valid_subscription_levels".to_owned(),
             data: WebSocketMessageResponse::GetValidSubscriptionLevels {
                 valid_subscription_levels: subscription_list,
             },

--- a/src/websockets/routes/transactions.rs
+++ b/src/websockets/routes/transactions.rs
@@ -131,7 +131,6 @@ pub async fn make_transaction(
         ok: Some(true),
         id: msg_id,
         r#type: WebSocketMessageInner::Response {
-            responding_to: "make_transaction".to_owned(),
             data: WebSocketMessageResponse::MakeTransaction {
                 transaction: transaction.into(),
             },


### PR DESCRIPTION
Another small PR for something that I found making a crate. The "responding_to" field was declared as both a field of the WebSocketMessage::Response variant, and tag of the variant's data field which is a flattened enum. This led to the serialized JSON having duplicate fields.

Haven't tested it because it's late and I don't have a proper test rig yet, but it compiles and nothing gets angry that I got rid of the field. Can't be sure though.