### PR TITLE
fix: don't count serverwelf in supply

### DIFF
--- a/src/routes/krist/misc.rs
+++ b/src/routes/krist/misc.rs
@@ -103,7 +103,7 @@ async fn get_v2_address(query: web::Json<LoginDetails>) -> Result<HttpResponse, 
 async fn get_kromer_supply(state: web::Data<AppState>) -> Result<HttpResponse, KristError> {
     let pool = &state.pool;
 
-    let money_supply: Decimal = sqlx::query_scalar("SELECT SUM(balance) FROM wallets")
+    let money_supply: Decimal = sqlx::query_scalar("SELECT COALESCE(SUM(balance), 0) FROM wallets WHERE address != 'serverwelf'")
         .fetch_one(pool)
         .await?;
 


### PR DESCRIPTION
Just a small fix to not count `serverwelf` in supply. Dima mentioned this as planned a couple weeks ago and no one got around to doing it so here it is.

Tested it and it works fine. Used COALESCE here for the case where there are no wallets besides `serverwelf`. Shouldn't actually matter in production but still.